### PR TITLE
Pull request for ByteBuffer update

### DIFF
--- a/C64Studio/Controls/HexBoxSpriteViewer.cs
+++ b/C64Studio/Controls/HexBoxSpriteViewer.cs
@@ -68,28 +68,29 @@ namespace Be.Windows.Forms
           {
             spriteData.SetU8At( i, Box.ByteProvider.ReadByte( firstTrueByte + ( j - firstSprite ) * 64 + i ) );
           }
-          GR.Image.FastImage  spriteImage = new GR.Image.FastImage( 24, 21, System.Drawing.Imaging.PixelFormat.Format8bppIndexed );
-          spriteImage.Box( 0, 0, 24, 21, 1 );
-          C64Studio.CustomRenderer.PaletteManager.ApplyPalette( spriteImage );
-
-          if ( MultiColor )
+          using ( GR.Image.FastImage spriteImage = new GR.Image.FastImage( 24, 21, System.Drawing.Imaging.PixelFormat.Format8bppIndexed ) )
           {
-            SpriteDisplayer.DisplayMultiColorSprite( spriteData, BackgroundColor, MultiColor1, MultiColor2, CustomColor, spriteImage, 0, 0 );
+            spriteImage.Box( 0, 0, 24, 21, 1 );
+            C64Studio.CustomRenderer.PaletteManager.ApplyPalette( spriteImage );
+
+            if ( MultiColor )
+            {
+              SpriteDisplayer.DisplayMultiColorSprite( spriteData, BackgroundColor, MultiColor1, MultiColor2, CustomColor, spriteImage, 0, 0 );
+            }
+            else
+            {
+              SpriteDisplayer.DisplayHiResSprite( spriteData, BackgroundColor, CustomColor, spriteImage, 0, 0 );
+            }
+
+            int     offsetY = (int)( Box.CharSize.Height * ( j - firstSprite ) * 8 + ( Box.CharSize.Height * 8 - spriteSize ) / 2 ) - (int)( Box.CharSize.Height * firstLineOffset );
+
+            using ( System.Drawing.Image img = spriteImage.GetAsBitmap() )
+            {
+              graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+
+              graphics.DrawImage( img, new Rectangle( _recHex.Left, _recHex.Top + offsetY, spriteSize, spriteSize ) );
+            }
           }
-          else
-          {
-            SpriteDisplayer.DisplayHiResSprite( spriteData, BackgroundColor, CustomColor, spriteImage, 0, 0 );
-          }
-
-          int     offsetY = (int)( Box.CharSize.Height * ( j - firstSprite ) * 8 + ( Box.CharSize.Height * 8 - spriteSize ) / 2 ) - (int)( Box.CharSize.Height * firstLineOffset );
-
-          System.Drawing.Image    img = spriteImage.GetAsBitmap();
-
-          graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
-
-          graphics.DrawImage( img, new Rectangle( _recHex.Left, _recHex.Top + offsetY, spriteSize, spriteSize ) );
-
-          img.Dispose();
         }
 
         graphics.Clip = oldClip;

--- a/Common/Common/ByteBuffer.cs
+++ b/Common/Common/ByteBuffer.cs
@@ -9,11 +9,10 @@ namespace GR
 	  /// </summary>
 	  public class ByteBuffer
 	  {
-      private static readonly byte[] EmptyByteArray = new byte[0];  // alternatively use System.Array.Empty<byte>()
+      private static readonly byte[] EmptyByteArray = new byte[0];  // alternatively alias System.Array.Empty<byte>()
 
       private System.Runtime.InteropServices.GCHandle   m_PinnedHandle = default( System.Runtime.InteropServices.GCHandle );
 
-      //private byte[] m_Data = new byte[0];
       private byte[] m_Data = EmptyByteArray;
 
       private UInt32 m_UsedBytes = 0;
@@ -148,15 +147,10 @@ namespace GR
         if ( ( iIndex < 0 )
         ||   ( iIndex + iBytes >= Length ) )
         {
-          //return new byte[0];
           return EmptyByteArray;
         }
         byte[] bReturn = new byte[iBytes];
 
-        //for ( int i = 0; i < iBytes; ++i )
-        //{
-        //  bReturn[i] = m_Data[iIndex + i];
-        //}
         Array.Copy( m_Data, iIndex, bReturn, 0, iBytes );
         return bReturn;
       }
@@ -380,10 +374,6 @@ namespace GR
         {
           m_Data = new byte[iLength];
 
-          //for ( int i = 0; i < iLength; ++i )
-          //{
-          //  m_Data[i] = bData[iStartIndex + i];
-          //}
           Array.Copy( bData, iStartIndex, m_Data, 0, iLength );
           m_UsedBytes = (UInt32)iLength;
         }
@@ -391,10 +381,6 @@ namespace GR
         {
           if ( m_UsedBytes + iLength <= m_Data.Length )
           {
-            //for ( int i = 0; i < iLength; ++i )
-            //{
-            //  m_Data[m_UsedBytes + i] = bData[iStartIndex + i];
-            //}
             Array.Copy( bData, iStartIndex, m_Data, m_UsedBytes, iLength );
             m_UsedBytes += (UInt32)iLength;
           }
@@ -403,10 +389,6 @@ namespace GR
             byte[] bTemp = new byte[m_Data.Length + iLength];
 
             m_Data.CopyTo( bTemp, 0 );
-            //for ( int i = 0; i < iLength; ++i )
-            //{
-            //  bTemp[m_Data.Length + i] = bData[iStartIndex + i];
-            //}
             Array.Copy( bData, iStartIndex, bTemp, m_Data.Length, iLength );
             m_Data = bTemp;
             m_UsedBytes = (UInt32)m_Data.Length;
@@ -483,7 +465,6 @@ namespace GR
 
       public void Clear()
       {
-        //m_Data = new byte[0];
         m_Data = EmptyByteArray;
         m_UsedBytes = 0;
       }
@@ -513,17 +494,6 @@ namespace GR
 
       public override string ToString()
       {
-        //if ( m_Data != null )
-        //{
-        //  System.Text.StringBuilder sb = new System.Text.StringBuilder();
-        //
-        //  for ( int i = 0; i < m_UsedBytes; i++ )
-        //  {
-        //    sb.Append( m_Data[i].ToString( "X2" ) );
-        //  }
-        //  return sb.ToString();
-        //}
-        //return "";
         return ArrayToHexString( m_Data, 0, (int)m_UsedBytes );
       }
 
@@ -541,13 +511,6 @@ namespace GR
         }
         UInt32 iAnzahl = m_UsedBytes - iStartIndex;
 
-        //string    strDatenInHexFormat = "";
-        //
-        //for ( UInt32 i = iStartIndex; i < iStartIndex + iAnzahl; i++ )
-        //{
-        //  strDatenInHexFormat += m_Data[i].ToString( "X2" );
-        //}
-        //return strDatenInHexFormat;
         return ArrayToHexString( m_Data, (int)iStartIndex, (int)iAnzahl );
       }
 
@@ -566,14 +529,7 @@ namespace GR
           return "";
         }
 
-        //string    strDatenInHexFormat = "";
-        //
-        //for ( int i = 0; i < iAnzahl; i++ )
-        //{
-        //  strDatenInHexFormat += m_Data[iStartIndex + i].ToString( "X2" );
-        //}
-        //return strDatenInHexFormat;
-        return ArrayToHexString( m_Data, (int)iStartIndex, iAnzahl );
+        return ArrayToHexString( m_Data, iStartIndex, iAnzahl );
       }
 
 
@@ -720,12 +676,7 @@ namespace GR
         }
         byte[] bTemp = new byte[BytesToReserve];
 
-        System.Diagnostics.Debug.Assert( Array.TrueForAll( bTemp, bTempItem => (bTempItem == 0) ), "Double-check assumptions about removed code (after next line) [1]" );
         m_Data.CopyTo( bTemp, 0 );
-        //for ( int i = m_Data.Length; i < BytesToReserve; ++i )
-        //{
-        //  bTemp[i] = 0;
-        //}
         m_Data = bTemp;
       }
 
@@ -734,11 +685,6 @@ namespace GR
         if ( m_Data == null )
         {
           m_Data = new byte[iSize];
-          //for ( int i = 0; i < iSize; ++i )
-          //{
-          //  m_Data[i] = 0;
-          //}
-          System.Diagnostics.Debug.Assert( Array.TrueForAll( m_Data, m_DataItem => (m_DataItem == 0) ), "Double-check assumptions about removed code (after next line) [2]" );
         }
         else
         {
@@ -749,24 +695,7 @@ namespace GR
           }
           byte[] bTemp = new byte[iSize];
 
-          System.Diagnostics.Debug.Assert( ( m_Data.Length < iSize ), "Double-check assumptions about removed code (if-else clause) [3]" );
-          //if ( m_Data.Length < iSize )
-          //{
-            System.Diagnostics.Debug.Assert( Array.TrueForAll( bTemp, bTempItem => (bTempItem == 0) ), "Double-check assumptions about removed code (after next line) [4]" );
-            m_Data.CopyTo( bTemp, 0 );
-            //for ( int i = m_Data.Length; i < iSize; ++i )
-            //{
-            //  bTemp[i] = 0;
-            //}
-          //}
-          //else
-          //{
-          //  System.Diagnostics.Debug.Fail( "Double-check assumptions about removed code (immediately below) [5]" );
-          //  //for ( int i = 0; i < iSize; ++i )
-          //  //{
-          //  //  bTemp[i] = m_Data[i];
-          //  //}
-          //}
+          m_Data.CopyTo( bTemp, 0 );
           m_Data = bTemp;
         }
         m_UsedBytes = iSize;

--- a/Common/Common/ByteBuffer.cs
+++ b/Common/Common/ByteBuffer.cs
@@ -9,9 +9,12 @@ namespace GR
 	  /// </summary>
 	  public class ByteBuffer
 	  {
+      private static readonly byte[] EmptyByteArray = new byte[0];  // alternatively use System.Array.Empty<byte>()
+
       private System.Runtime.InteropServices.GCHandle   m_PinnedHandle = default( System.Runtime.InteropServices.GCHandle );
 
-      private byte[] m_Data = new byte[0];
+      //private byte[] m_Data = new byte[0];
+      private byte[] m_Data = EmptyByteArray;
 
       private UInt32 m_UsedBytes = 0;
 
@@ -145,14 +148,16 @@ namespace GR
         if ( ( iIndex < 0 )
         ||   ( iIndex + iBytes >= Length ) )
         {
-          return new byte[0];
+          //return new byte[0];
+          return EmptyByteArray;
         }
         byte[] bReturn = new byte[iBytes];
 
-        for ( int i = 0; i < iBytes; ++i )
-        {
-          bReturn[i] = m_Data[iIndex + i];
-        }
+        //for ( int i = 0; i < iBytes; ++i )
+        //{
+        //  bReturn[i] = m_Data[iIndex + i];
+        //}
+        Array.Copy( m_Data, iIndex, bReturn, 0, iBytes );
         return bReturn;
       }
 
@@ -375,20 +380,22 @@ namespace GR
         {
           m_Data = new byte[iLength];
 
-          for ( int i = 0; i < iLength; ++i )
-          {
-            m_Data[i] = bData[iStartIndex + i];
-          }
+          //for ( int i = 0; i < iLength; ++i )
+          //{
+          //  m_Data[i] = bData[iStartIndex + i];
+          //}
+          Array.Copy( bData, iStartIndex, m_Data, 0, iLength );
           m_UsedBytes = (UInt32)iLength;
         }
         else
         {
           if ( m_UsedBytes + iLength <= m_Data.Length )
           {
-            for ( int i = 0; i < iLength; ++i )
-            {
-              m_Data[m_UsedBytes + i] = bData[iStartIndex + i];
-            }
+            //for ( int i = 0; i < iLength; ++i )
+            //{
+            //  m_Data[m_UsedBytes + i] = bData[iStartIndex + i];
+            //}
+            Array.Copy( bData, iStartIndex, m_Data, m_UsedBytes, iLength );
             m_UsedBytes += (UInt32)iLength;
           }
           else
@@ -396,10 +403,11 @@ namespace GR
             byte[] bTemp = new byte[m_Data.Length + iLength];
 
             m_Data.CopyTo( bTemp, 0 );
-            for ( int i = 0; i < iLength; ++i )
-            {
-              bTemp[m_Data.Length + i] = bData[iStartIndex + i];
-            }
+            //for ( int i = 0; i < iLength; ++i )
+            //{
+            //  bTemp[m_Data.Length + i] = bData[iStartIndex + i];
+            //}
+            Array.Copy( bData, iStartIndex, bTemp, m_Data.Length, iLength );
             m_Data = bTemp;
             m_UsedBytes = (UInt32)m_Data.Length;
           }
@@ -475,7 +483,8 @@ namespace GR
 
       public void Clear()
       {
-        m_Data = new byte[0];
+        //m_Data = new byte[0];
+        m_Data = EmptyByteArray;
         m_UsedBytes = 0;
       }
 
@@ -504,17 +513,18 @@ namespace GR
 
       public override string ToString()
       {
-        if ( m_Data != null )
-        {
-          System.Text.StringBuilder sb = new System.Text.StringBuilder();
-
-          for ( int i = 0; i < m_UsedBytes; i++ )
-			    {
-            sb.Append( m_Data[i].ToString( "X2" ) );
-			    }
-			    return sb.ToString();
-        }
-        return "";
+        //if ( m_Data != null )
+        //{
+        //  System.Text.StringBuilder sb = new System.Text.StringBuilder();
+        //
+        //  for ( int i = 0; i < m_UsedBytes; i++ )
+        //  {
+        //    sb.Append( m_Data[i].ToString( "X2" ) );
+        //  }
+        //  return sb.ToString();
+        //}
+        //return "";
+        return ArrayToHexString( m_Data, 0, (int)m_UsedBytes );
       }
 
 
@@ -531,13 +541,14 @@ namespace GR
         }
         UInt32 iAnzahl = m_UsedBytes - iStartIndex;
 
-			  string    strDatenInHexFormat = "";
-
-        for ( UInt32 i = iStartIndex; i < iStartIndex + iAnzahl; i++ )
-			  {
-				  strDatenInHexFormat += m_Data[i].ToString( "X2" );
-			  }
-			  return strDatenInHexFormat;
+        //string    strDatenInHexFormat = "";
+        //
+        //for ( UInt32 i = iStartIndex; i < iStartIndex + iAnzahl; i++ )
+        //{
+        //  strDatenInHexFormat += m_Data[i].ToString( "X2" );
+        //}
+        //return strDatenInHexFormat;
+        return ArrayToHexString( m_Data, (int)iStartIndex, (int)iAnzahl );
       }
 
       public string ToString( int iStartIndex, int iAnzahl )
@@ -555,13 +566,38 @@ namespace GR
           return "";
         }
 
-			  string    strDatenInHexFormat = "";
+        //string    strDatenInHexFormat = "";
+        //
+        //for ( int i = 0; i < iAnzahl; i++ )
+        //{
+        //  strDatenInHexFormat += m_Data[iStartIndex + i].ToString( "X2" );
+        //}
+        //return strDatenInHexFormat;
+        return ArrayToHexString( m_Data, (int)iStartIndex, iAnzahl );
+      }
 
-			  for ( int i = 0; i < iAnzahl; i++ )
-			  {
-          strDatenInHexFormat += m_Data[iStartIndex + i].ToString( "X2" );
-			  }
-			  return strDatenInHexFormat;
+
+
+      private static string ArrayToHexString( byte[] dataArray, int startIndex, int byteCount )
+      {
+        if ( dataArray == null )
+        {
+          return string.Empty;
+        }
+
+        var sb = new System.Text.StringBuilder( byteCount * 2 );
+
+        byte dataByte;
+        int stopIndex = startIndex + byteCount;
+        const string HexChars = "0123456789ABCDEF";
+        for ( int i = startIndex; i < stopIndex; i++ )
+        {
+          dataByte = dataArray[i];
+          sb.Append( HexChars[(int)(dataByte >> 4)] );
+          sb.Append( HexChars[(int)(dataByte & 0xF)] );
+        }
+
+        return sb.ToString();
       }
 
       public UInt32 Length
@@ -684,11 +720,12 @@ namespace GR
         }
         byte[] bTemp = new byte[BytesToReserve];
 
+        System.Diagnostics.Debug.Assert( Array.TrueForAll( bTemp, bTempItem => (bTempItem == 0) ), "Double-check assumptions about removed code (after next line) [1]" );
         m_Data.CopyTo( bTemp, 0 );
-        for ( int i = m_Data.Length; i < BytesToReserve; ++i )
-        {
-          bTemp[i] = 0;
-        }
+        //for ( int i = m_Data.Length; i < BytesToReserve; ++i )
+        //{
+        //  bTemp[i] = 0;
+        //}
         m_Data = bTemp;
       }
 
@@ -697,10 +734,11 @@ namespace GR
         if ( m_Data == null )
         {
           m_Data = new byte[iSize];
-          for ( int i = 0; i < iSize; ++i )
-          {
-            m_Data[i] = 0;
-          }
+          //for ( int i = 0; i < iSize; ++i )
+          //{
+          //  m_Data[i] = 0;
+          //}
+          System.Diagnostics.Debug.Assert( Array.TrueForAll( m_Data, m_DataItem => (m_DataItem == 0) ), "Double-check assumptions about removed code (after next line) [2]" );
         }
         else
         {
@@ -710,22 +748,25 @@ namespace GR
             return;
           }
           byte[] bTemp = new byte[iSize];
-          
-          if ( m_Data.Length < iSize )
-          {
+
+          System.Diagnostics.Debug.Assert( ( m_Data.Length < iSize ), "Double-check assumptions about removed code (if-else clause) [3]" );
+          //if ( m_Data.Length < iSize )
+          //{
+            System.Diagnostics.Debug.Assert( Array.TrueForAll( bTemp, bTempItem => (bTempItem == 0) ), "Double-check assumptions about removed code (after next line) [4]" );
             m_Data.CopyTo( bTemp, 0 );
-            for ( int i = m_Data.Length; i < iSize; ++i )
-            {
-              bTemp[i] = 0;
-            }
-          }
-          else
-          {
-            for ( int i = 0; i < iSize; ++i )
-            {
-              bTemp[i] = m_Data[i];
-            }
-          }
+            //for ( int i = m_Data.Length; i < iSize; ++i )
+            //{
+            //  bTemp[i] = 0;
+            //}
+          //}
+          //else
+          //{
+          //  System.Diagnostics.Debug.Fail( "Double-check assumptions about removed code (immediately below) [5]" );
+          //  //for ( int i = 0; i < iSize; ++i )
+          //  //{
+          //  //  bTemp[i] = m_Data[i];
+          //  //}
+          //}
           m_Data = bTemp;
         }
         m_UsedBytes = iSize;


### PR DESCRIPTION
Mainly to use .NET's built-in array methods instead of copying data using for-loops, and removed redundant clearing of new array data -- should be slightly faster, and it looks like everything still works as expected (primary testing done on the VICE API).

Note: The changes dated January 4 and 5 were already merged manually.