### PR TITLE
Supporting alternative Debug.Log viewers

### DIFF
--- a/Common/Common/debug.cs
+++ b/Common/Common/debug.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices;
       public System.IntPtr pData;
     };
 
+    //[System.Diagnostics.Conditional( "DEBUG" )]  // When needed, uncomment this line to remove debug logging from Release builds
     static public void Log( string sText )
     {
       int   iWnd = FindWindow( null, "DebugHost V2" );
@@ -38,6 +39,10 @@ using System.Runtime.InteropServices;
 
         System.Runtime.InteropServices.Marshal.FreeHGlobal( iPtr );
         System.Runtime.InteropServices.Marshal.FreeHGlobal( cds.pData );
+      }
+      else
+      {
+        System.Diagnostics.Trace.WriteLine( sText );
       }
     }
 	}


### PR DESCRIPTION
Allow the use of alternative Debug.Log viewers, other than only DebugHost. 

With this change, when DebugHost is not running, debug logging will now be displayed in Visual Studio's Output window, in DebugView (dbgview) of Sysinternals, or other similar loggers. 

Furthermore, debug logging can now be disabled more easily for Release builds (when needed) by simply uncommenting the single line above Debug.Log's implementation (i.e., by including that Conditional line).