### PR TITLE
Add real version number to C64Studio.exe's Properties|Details tab for Windows Explorer

### DIFF
--- a/C64Studio/Properties/AssemblyInfo.cs
+++ b/C64Studio/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "GR Games" )]
 [assembly: AssemblyProduct( "C64Studio" )]
-[assembly: AssemblyCopyright( "Copyright © GR Games 2011" )]
+[assembly: AssemblyCopyright( "Copyright © GR Games 2011–2019" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.0.0.0" )]
-[assembly: AssemblyFileVersion( "1.0.0.0" )]
+[assembly: AssemblyVersion( C64Studio.StudioCore.StudioVersion )]
+[assembly: AssemblyFileVersion( C64Studio.StudioCore.StudioVersion )]

--- a/C64Studio/StudioCore.cs
+++ b/C64Studio/StudioCore.cs
@@ -19,7 +19,7 @@ namespace C64Studio
     public Executing          Executing;
     public Tasks.TaskManager  TaskManager;
     public bool               ShuttingDown = false;
-    public static string      StudioVersion = "5.9";
+    public const string       StudioVersion = "5.9";
     public StudioTheme        Theming;
 
     public static StudioCore  StaticCore = null;


### PR DESCRIPTION
Keeps version in sync with StudioCore string. (And refreshed the Copyright year.)

This pull-request is also a test for upstream issue https://github.com/GeorgRottensteiner/C64Studio/issues/11 - "No email notifications on Pull requests"