### PR TITLE
Enable OK Button on paste

### DIFF
--- a/C64Studio/Dialogs/FormWizard.Designer.cs
+++ b/C64Studio/Dialogs/FormWizard.Designer.cs
@@ -62,6 +62,7 @@
       this.editPathACME.Name = "editPathACME";
       this.editPathACME.Size = new System.Drawing.Size( 376, 20 );
       this.editPathACME.TabIndex = 0;
+      this.editPathACME.TextChanged += new System.EventHandler(this.editPath_TextChanged);
       // 
       // btnBrowseACME
       // 
@@ -88,6 +89,7 @@
       this.editPathVice.Name = "editPathVice";
       this.editPathVice.Size = new System.Drawing.Size( 376, 20 );
       this.editPathVice.TabIndex = 2;
+      this.editPathVice.TextChanged += new System.EventHandler(this.editPath_TextChanged);
       // 
       // btnBrowseVice
       // 

--- a/C64Studio/Dialogs/FormWizard.cs
+++ b/C64Studio/Dialogs/FormWizard.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO;
 using System.Text;
 using System.Windows.Forms;
 
@@ -45,8 +46,6 @@ namespace C64Studio
       if ( dlgBrowse.ShowDialog() == DialogResult.OK )
       {
         editPathACME.Text = dlgBrowse.FileName;
-
-        btnOK.Enabled = ( ( editPathACME.Text.Length > 0 ) || ( editPathVice.Text.Length > 0 ) );
       }
     }
 
@@ -62,9 +61,17 @@ namespace C64Studio
       if ( dlgBrowse.ShowDialog() == DialogResult.OK )
       {
         editPathVice.Text = dlgBrowse.FileName;
-        //btnOK.Enabled = ( ( editPathACME.Text.Length > 0 ) || ( editPathVice.Text.Length > 0 ) );
-        btnOK.Enabled = ( editPathVice.Text.Length > 0 );
       }
+    }
+
+    private void editPath_TextChanged( object sender, EventArgs e )
+    {
+      EnableOK();
+    }
+
+    private void EnableOK()
+    {
+      btnOK.Enabled = ( ( editPathVice.Text.Length > 0 && File.Exists(editPathVice.Text) ) || ( editPathACME.Text.Length > 0 && File.Exists(editPathACME.Text) ) );
     }
 
   }


### PR DESCRIPTION
Fixes #42

I have a couple of questions:
1. Should the test for the file's existence perhaps be moved to the OK click button handler and be a warning?  Or is it better where it is?
2. When pasting the path from Windows File Explorer, it puts double quotes around the entire path.  Would you prefer these to be removed?