### PR TITLE
Make memory PETSCII/character views have selectable byte width

### DIFF
--- a/C64Studio/Controls/HexBoxCharPETSCIIViewer.cs
+++ b/C64Studio/Controls/HexBoxCharPETSCIIViewer.cs
@@ -26,6 +26,7 @@ namespace Be.Windows.Forms
 
         GR.Image.FastImage  charImage = new GR.Image.FastImage( 8, 8, GR.Drawing.PixelFormat.Format32bppRgb );
         PaletteManager.ApplyPalette( charImage );
+        int chars = Box.BytesPerLine;
 
         for ( int i = 0; i < intern_endByte - _startByte; ++i )
         {
@@ -57,8 +58,8 @@ namespace Be.Windows.Forms
           }
 
           charImage.DrawToHDC( graphics.GetHdc(),
-                               new Rectangle( _recHex.Left + (int)Box.CharSize.Width * ( i % 8 ), 
-                                              (int)( _recHex.Top + ( i / 8 ) * (int)Box.CharSize.Height + ( Box.CharSize.Height - Box.CharSize.Width ) / 2 ), 
+                               new Rectangle( _recHex.Left + (int)Box.CharSize.Width * ( i % chars ), 
+                                              (int)( _recHex.Top + ( i / chars ) * (int)Box.CharSize.Height + ( Box.CharSize.Height - Box.CharSize.Width ) / 2 ), 
                                               (int)Box.CharSize.Width, 
                                               (int)Box.CharSize.Width ) );
           graphics.ReleaseHdc();

--- a/C64Studio/Documents/DebugMemory.Designer.cs
+++ b/C64Studio/Documents/DebugMemory.Designer.cs
@@ -28,6 +28,11 @@
     /// </summary>
     private void InitializeComponent()
     {
+      System.Windows.Forms.ToolStripMenuItem toolStripMenuItem5;
+      System.Windows.Forms.ToolStripMenuItem toolStripMenuItem6;
+      System.Windows.Forms.ToolStripMenuItem toolStripMenuItem7;
+      System.Windows.Forms.ToolStripMenuItem toolStripMenuItem8;
+      System.Windows.Forms.ToolStripMenuItem toolStripMenuItem9;
       System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DebugMemory));
       this.hexView = new Be.Windows.Forms.HexBox();
       this.toolDebugMemory = new System.Windows.Forms.ToolStrip();
@@ -40,10 +45,56 @@
       this.toolStripBtnHexCaseSwitch = new System.Windows.Forms.ToolStripButton();
       this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
       this.toolStripBtnAddView = new System.Windows.Forms.ToolStripButton();
+      this.byteWidthDropDownButton = new System.Windows.Forms.ToolStripDropDownButton();
+      toolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
+      toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
+      toolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
+      toolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
+      toolStripMenuItem9 = new System.Windows.Forms.ToolStripMenuItem();
       ((System.ComponentModel.ISupportInitialize)(this.m_FileWatcher)).BeginInit();
       this.toolDebugMemory.SuspendLayout();
       this.SuspendLayout();
       // 
+      // toolStripMenuItem5
+      // 
+      toolStripMenuItem5.AutoSize = false;
+      toolStripMenuItem5.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      toolStripMenuItem5.Name = "toolStripMenuItem5";
+      toolStripMenuItem5.Size = new System.Drawing.Size(100, 34);
+      toolStripMenuItem5.Text = "8";
+      // 
+      // toolStripMenuItem6
+      // 
+      toolStripMenuItem6.AutoSize = false;
+      toolStripMenuItem6.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      toolStripMenuItem6.Name = "toolStripMenuItem6";
+      toolStripMenuItem6.Size = new System.Drawing.Size(100, 34);
+      toolStripMenuItem6.Text = "16";
+      // 
+      // toolStripMenuItem7
+      // 
+      toolStripMenuItem7.AutoSize = false;
+      toolStripMenuItem7.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      toolStripMenuItem7.Name = "toolStripMenuItem7";
+      toolStripMenuItem7.Size = new System.Drawing.Size(100, 34);
+      toolStripMenuItem7.Text = "24";
+      // 
+      // toolStripMenuItem8
+      // 
+      toolStripMenuItem8.AutoSize = false;
+      toolStripMenuItem8.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      toolStripMenuItem8.Name = "toolStripMenuItem8";
+      toolStripMenuItem8.Size = new System.Drawing.Size(100, 34);
+      toolStripMenuItem8.Text = "32";
+      // 
+      // toolStripMenuItem9
+      // 
+      toolStripMenuItem9.AutoSize = false;
+      toolStripMenuItem9.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      toolStripMenuItem9.Name = "toolStripMenuItem9";
+      toolStripMenuItem9.Size = new System.Drawing.Size(100, 34);
+      toolStripMenuItem9.Text = "40";
+      //
       // hexView
       // 
       this.hexView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -79,6 +130,7 @@
             this.toolStripBtnMemoryFromCPU,
             this.toolStripBtnGoto,
             this.toolStripBtnHexCaseSwitch,
+			this.byteWidthDropDownButton,
             this.toolStripSeparator2,
             this.toolStripBtnAddView});
       this.toolDebugMemory.Location = new System.Drawing.Point(0, 0);
@@ -175,6 +227,16 @@
       this.toolStripBtnAddView.Text = "Add View";
       this.toolStripBtnAddView.Click += new System.EventHandler(this.toolStripBtnAddView_Click);
       // 
+      // byteWidthDropDownButton
+      // 
+      this.byteWidthDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+      this.byteWidthDropDownButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripMenuItem5, toolStripMenuItem6, toolStripMenuItem7, toolStripMenuItem8, toolStripMenuItem9 });
+      this.byteWidthDropDownButton.Image = Properties.Resources.tool_select;
+      this.byteWidthDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.byteWidthDropDownButton.Name = "byteWidthDropDownButton";
+      this.byteWidthDropDownButton.Size = new System.Drawing.Size(42, 28);
+      this.byteWidthDropDownButton.ToolTipText = "Bytes per line";
+      this.byteWidthDropDownButton.DropDownItemClicked += byteWidthDropDownButton_DropDownItemClicked;
       // DebugMemory
       // 
       this.ClientSize = new System.Drawing.Size(431, 485);
@@ -191,18 +253,19 @@
 
     }
 
-    #endregion
+        #endregion
 
-    public Be.Windows.Forms.HexBox hexView;
-    private System.Windows.Forms.ToolStrip toolDebugMemory;
-    private System.Windows.Forms.ToolStripButton btnBinaryStringView;
-    private System.Windows.Forms.ToolStripButton btnBinaryCharView;
-    private System.Windows.Forms.ToolStripButton btnBinarySpriteView;
-    private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-    private System.Windows.Forms.ToolStripButton toolStripBtnMemoryFromCPU;
-    private System.Windows.Forms.ToolStripButton toolStripBtnGoto;
-    private System.Windows.Forms.ToolStripButton toolStripBtnHexCaseSwitch;
-    private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-    private System.Windows.Forms.ToolStripButton toolStripBtnAddView;
-  }
+        public Be.Windows.Forms.HexBox hexView;
+        private System.Windows.Forms.ToolStrip toolDebugMemory;
+        private System.Windows.Forms.ToolStripButton btnBinaryStringView;
+        private System.Windows.Forms.ToolStripButton btnBinaryCharView;
+        private System.Windows.Forms.ToolStripButton btnBinarySpriteView;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripButton toolStripBtnMemoryFromCPU;
+        private System.Windows.Forms.ToolStripButton toolStripBtnGoto;
+        private System.Windows.Forms.ToolStripButton toolStripBtnHexCaseSwitch;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        private System.Windows.Forms.ToolStripButton toolStripBtnAddView;
+        private System.Windows.Forms.ToolStripDropDownButton byteWidthDropDownButton;
+    }
 }

--- a/C64Studio/Documents/DebugMemory.cs
+++ b/C64Studio/Documents/DebugMemory.cs
@@ -44,6 +44,7 @@ namespace RetroDevStudio.Documents
 
     private Color                     ChangedColor = Color.Red;
     private Color                     UnchangedColor = Color.Black;
+    private int m_ByteWidth = 8;
 
 
 
@@ -96,6 +97,7 @@ namespace RetroDevStudio.Documents
       m_MenuItemHexSpriteView.Click += btnBinarySpriteView_Click;
       hexView.ContextMenuStrip.Items.Add( m_MenuItemHexSpriteView );
 
+      SelectByteWidth(8);
       SetMemoryDisplayType();
 
       ViewScrolled += new DebugMemory.DebugMemoryEventCallback( Core.MainForm.m_DebugMemory_ViewScrolled );
@@ -497,6 +499,8 @@ namespace RetroDevStudio.Documents
       m_MenuItemHexSpriteView.Checked = false;
       btnBinaryCharView.Checked = false;
       m_MenuItemHexCharView.Checked = false;
+
+      SelectByteWidth(m_ByteWidth);
       hexView.Invalidate();
       SetColorSubmenu();
     }
@@ -533,6 +537,7 @@ namespace RetroDevStudio.Documents
 
       ApplyHexViewColors();
 
+      SelectByteWidth(m_ByteWidth);
       hexView.Invalidate();
       SetColorSubmenu();
     }
@@ -568,6 +573,8 @@ namespace RetroDevStudio.Documents
 
       ApplyHexViewColors();
 
+      hexView.BytesPerLine = 8;
+      SelectByteWidth(0);
       hexView.Invalidate();
       SetColorSubmenu();
     }
@@ -669,5 +676,32 @@ namespace RetroDevStudio.Documents
 
 
 
+    private void SelectByteWidth(int w)
+    {
+        if (w == 0)
+        {
+            byteWidthDropDownButton.Enabled = false;
+        }
+        else
+        {
+            foreach (ToolStripMenuItem item in byteWidthDropDownButton.DropDownItems)
+            {
+                item.CheckState = item.Text == w.ToString() ? CheckState.Checked : CheckState.Unchecked;
+            }
+
+            hexView.BytesPerLine = w;
+            byteWidthDropDownButton.Enabled = true;
+        }
+        hexView.Invalidate();
+    }
+
+
+
+    private void byteWidthDropDownButton_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
+    {
+        int w = int.Parse(e.ClickedItem.Text);
+        SelectByteWidth(w);
+        m_ByteWidth = w;
+    }
   }
 }


### PR DESCRIPTION
Quick hack to loosen the 8 byte width of the char/petscii modes of the memory viewer