### PR TITLE
Ignore color byte on commander x16 enum values

### DIFF
--- a/C64Studio/Documents/SpriteEditor.cs
+++ b/C64Studio/Documents/SpriteEditor.cs
@@ -2822,7 +2822,11 @@ namespace RetroDevStudio.Documents
         {
           color |= 0x80;
         }
-        exportData.AppendU8( color );
+
+        if (! Enum.GetName( typeof( SpriteMode ), m_SpriteProject.Sprites[exportIndices[i]].Mode ).StartsWith( "COMMANDER_X16", StringComparison.OrdinalIgnoreCase ) )
+        {
+          exportData.AppendU8( color );
+        }
       }
       return exportData;
     }


### PR DESCRIPTION
I'm being presumptuous here, but I wanted to dive in and fix the issue :) I tried my best to follow your coding style.

This fix checks the name of the mode enum. If the name isn't related to the x16, it appends the color byte. This means any enum value that starts with the name `COMMANDER_X16...` won't have the color byte added.

Fixes #113