### PR TITLE
Fix: Charscreen editor external charset path was reset to empty after…

### DIFF
--- a/C64Studio/Dialogs/Preferences/DlgPrefBASICEditor.cs
+++ b/C64Studio/Dialogs/Preferences/DlgPrefBASICEditor.cs
@@ -31,17 +31,31 @@ namespace RetroDevStudio.Dialogs.Preferences
 
 
 
+    private void SetPreviewFont( Font NewFont )
+    {
+      Font  oldFont = labelBASICFontPreview.Font;
+      labelBASICFontPreview.Font = NewFont;
+      // dispose only fonts we own; the inherited parent font must not be disposed
+      if ( ( oldFont != null )
+      &&   ( oldFont != labelBASICFontPreview.Parent?.Font ) )
+      {
+        oldFont.Dispose();
+      }
+    }
+
+
+
     public override void ApplySettingsToControls()
     {
       checkBASICUseC64Font.Checked = !Core.Settings.BASICUseNonC64Font;
       editBASICC64FontSize.Enabled = !Core.Settings.BASICUseNonC64Font;
       if ( !Core.Settings.BASICUseNonC64Font )
       {
-        labelBASICFontPreview.Font = Core.Imaging.FontFromMachine( MachineType.C64, Core.Settings.BASICSourceFontSize );
+        SetPreviewFont( Core.Imaging.FontFromMachine( MachineType.C64, Core.Settings.BASICSourceFontSize ) );
       }
       else
       {
-        labelBASICFontPreview.Font = new Font( Core.Settings.BASICSourceFontFamily, Core.Settings.BASICSourceFontSize, Core.Settings.BASICSourceFontStyle );
+        SetPreviewFont( new Font( Core.Settings.BASICSourceFontFamily, Core.Settings.BASICSourceFontSize, Core.Settings.BASICSourceFontStyle ) );
       }
       editBASICC64FontSize.Text                           = ( (int)Core.Settings.BASICSourceFontSize ).ToString();
       editMaxLineLengthIndicatorColumn.Text               = Core.Settings.BASICShowMaxLineLengthIndicatorLength.ToString();
@@ -99,14 +113,14 @@ namespace RetroDevStudio.Dialogs.Preferences
 
         if ( !Core.Settings.BASICUseNonC64Font )
         {
-          labelBASICFontPreview.Font    = Core.Imaging.FontFromMachine( MachineType.C64, Core.Settings.BASICSourceFontSize );
+          SetPreviewFont( Core.Imaging.FontFromMachine( MachineType.C64, Core.Settings.BASICSourceFontSize ) );
           btnChangeBASICFont.Enabled    = false;
           labelBASICC64FontSize.Enabled = true;
           editBASICC64FontSize.Enabled  = true;
         }
         else
         {
-          labelBASICFontPreview.Font    = new Font( Core.Settings.BASICSourceFontFamily, Core.Settings.BASICSourceFontSize );
+          SetPreviewFont( new Font( Core.Settings.BASICSourceFontFamily, Core.Settings.BASICSourceFontSize ) );
           btnChangeBASICFont.Enabled    = true;
           labelBASICC64FontSize.Enabled = false;
           editBASICC64FontSize.Enabled  = false;
@@ -128,7 +142,7 @@ namespace RetroDevStudio.Dialogs.Preferences
         {
           Core.Settings.BASICSourceFontFamily = fontDialog.Font.FontFamily.Name;
           Core.Settings.BASICSourceFontSize   = fontDialog.Font.SizeInPoints;
-          labelBASICFontPreview.Font          = new Font( Core.Settings.BASICSourceFontFamily, Core.Settings.BASICSourceFontSize );
+          SetPreviewFont( new Font( Core.Settings.BASICSourceFontFamily, Core.Settings.BASICSourceFontSize ) );
 
           RefreshDisplayOnDocuments();
         }
@@ -152,7 +166,7 @@ namespace RetroDevStudio.Dialogs.Preferences
       if ( fontSize != Core.Settings.BASICSourceFontSize )
       {
         Core.Settings.BASICSourceFontSize = fontSize;
-        labelBASICFontPreview.Font = Core.Imaging.FontFromMachine( MachineType.C64, Core.Settings.BASICSourceFontSize );
+        SetPreviewFont( Core.Imaging.FontFromMachine( MachineType.C64, Core.Settings.BASICSourceFontSize ) );
         RefreshDisplayOnDocuments();
       }
     }

--- a/C64Studio/Documents/CharsetScreenEditor.cs
+++ b/C64Studio/Documents/CharsetScreenEditor.cs
@@ -1830,7 +1830,6 @@ namespace RetroDevStudio.Documents
           {
             m_CharsetScreen.ExternalCharset = GR.Path.RelativePathTo( filename, false, System.IO.Path.GetFullPath( DocumentInfo.Project.Settings.BasePath ), true );
           }
-          m_CharsetScreen.ExternalCharset = "";
           Modified = true;
           RecalcTileUsages();
           return true;

--- a/C64Studio/Documents/CharsetScreenEditor.cs
+++ b/C64Studio/Documents/CharsetScreenEditor.cs
@@ -2046,7 +2046,7 @@ namespace RetroDevStudio.Documents
             }
             if ( minY + height > CurrentScreen.Height )
             {
-              height = CurrentScreen.Height - minX;
+              height = CurrentScreen.Height - minY;
             }
             return new GR.Math.Rectangle( minX, minY, width, height );
           }

--- a/Common/Parser/Assembler/ASMFileParser.cs
+++ b/Common/Parser/Assembler/ASMFileParser.cs
@@ -140,7 +140,7 @@ namespace RetroDevStudio.Parser
           m_TextCodeMappingScr[byteValue] = (byte)( byteValue - 'a' + 1 );
           m_TextCodeMappingPet[byteValue] = (byte)( byteValue - ( 'a' - 'A' ) );
         }
-        else if ( byteValue == (byte)'£' )
+        else if ( byteValue == 0xA3 )
         {
           m_TextCodeMappingScr[byteValue] = (byte)28;
           m_TextCodeMappingPet[byteValue] = (byte)92;


### PR DESCRIPTION
… import

The line that reset ExternalCharset to an empty string after it was just set to the imported charset path has been removed, so the path is now retained.