### PR TITLE
Vergleichsoperator in if-Anweisung korrigiert

### DIFF
--- a/C64Studio/FileParser.cs
+++ b/C64Studio/FileParser.cs
@@ -728,7 +728,7 @@ namespace C64Studio
       }
       else if ( Operator == "<=" )
       {
-        if ( Token1 > Token2 )
+        if ( Token1 <= Token2 )
         {
           Result = 1;
         }


### PR DESCRIPTION
Die Bedingung prüft nun korrekt, ob Token1 <= Token2, statt wie zuvor Token1 > Token2.