### PR TITLE
Fix GDI+ handle leak of highlight brush in ImageListbox.OnPaint

### DIFF
--- a/Common/Common/ImageListbox.cs
+++ b/Common/Common/ImageListbox.cs
@@ -1042,8 +1042,10 @@ namespace GR.Forms
 
         if ( Items[itemIndex].Highlighted )
         {
-          System.Drawing.SolidBrush highlightColorBrush = new System.Drawing.SolidBrush( GR.Color.Helper.FromARGB( m_HighlightColors[Items[itemIndex].HighlightGroup % m_HighlightColors.Count] ) );
-          e.Graphics.FillRectangle( highlightColorBrush, ItemRect( itemIndex ) );
+          using ( System.Drawing.SolidBrush highlightColorBrush = new System.Drawing.SolidBrush( GR.Color.Helper.FromARGB( m_HighlightColors[Items[itemIndex].HighlightGroup % m_HighlightColors.Count] ) ) )
+          {
+            e.Graphics.FillRectangle( highlightColorBrush, ItemRect( itemIndex ) );
+          }
         }
         if ( m_SelectedIndices.Contains( itemIndex ) )
         {


### PR DESCRIPTION
That's how it always starts. Very small.