### PR TITLE
Fix out-of-bounds palette index from unmasked VIC color register writes

### DIFF
--- a/Common/Emulator/C64/VIC.cs
+++ b/Common/Emulator/C64/VIC.cs
@@ -547,6 +547,12 @@ namespace Tiny64
       }
       else
       {
+        // VIC-II color registers only use the lower 4 bits of a written value
+        if ( ( register == Register.BORDER_COLOR )
+        ||   ( register == Register.BACKGROUND_COLOR ) )
+        {
+          Value &= 0x0f;
+        }
         Registers[Address] = Value;
         switch ( register )
         {

--- a/Tiny64Emu/Display.cs
+++ b/Tiny64Emu/Display.cs
@@ -75,6 +75,11 @@ namespace Tiny64
 
 		public unsafe void SetPixel( int X, int Y, byte Color )
 		{
+			// defensive bounds check - palette holds 17 entries, clamp invalid colors to black
+			if ( Color >= 17 )
+			{
+				Color = 0;
+			}
 			_bitmapPtr[X + Y * 504] = _ColorValues[Color];
 		}
 


### PR DESCRIPTION
the next one please