### PR TITLE
Fix missing ContainsKey check before lineNumberReference access in Ba…

### DIFF
--- a/Common/Parser/BASIC/BasicFileParser.cs
+++ b/Common/Parser/BASIC/BasicFileParser.cs
@@ -4940,7 +4940,8 @@ namespace RetroDevStudio.Parser.BASIC
               lineInfo.LineNumber = GR.Convert.ToI32( token.Content );
             }
             if ( ( lineInfo.LineNumber >= FirstLineNumber )
-            &&   ( lineInfo.LineNumber <= LastLineNumber ) )
+            &&   ( lineInfo.LineNumber <= LastLineNumber )
+            &&   ( lineNumberReference.ContainsKey( lineInfo.LineNumber ) ) )
             {
               sb.Append( lineNumberReference[lineInfo.LineNumber] );
             }
@@ -4987,7 +4988,8 @@ namespace RetroDevStudio.Parser.BASIC
                       ++i;
                     }
                     if ( ( refNo >= FirstLineNumber )
-                    &&   ( refNo <= LastLineNumber ) )
+                    &&   ( refNo <= LastLineNumber )
+                    &&   ( lineNumberReference.ContainsKey( refNo ) ) )
                     {
                       sb.Append( lineNumberReference[refNo] );
                     }
@@ -5028,7 +5030,8 @@ namespace RetroDevStudio.Parser.BASIC
                     ++i;
                   }
                   if ( ( refNo >= FirstLineNumber )
-                  &&   ( refNo <= LastLineNumber ) )
+                  &&   ( refNo <= LastLineNumber )
+                  &&   ( lineNumberReference.ContainsKey( refNo ) ) )
                   {
                     sb.Append( lineNumberReference[refNo] );
                   }


### PR DESCRIPTION
Sprungziele auf reine Kommentarzeilen im Renumber-Bereich wurden durch die stillschweigende Default-Einsetzung des Map-Indexers auf Zeile 0 umgeschrieben. Drei ungeschützte Lese-Zweige prüfen nun mit ContainsKey und behalten bei fehlendem Eintrag die Original-Zeilennummer bei (analog zum korrekt abgesicherten AllowsSeveralLineNumbers-Zweig).