### PR TITLE
Fix infinite loop in FindNextOccurrence for whole-word upwards search

### DIFF
--- a/C64Studio/Dialogs/FormFindReplace.cs
+++ b/C64Studio/Dialogs/FormFindReplace.cs
@@ -565,8 +565,16 @@ namespace RetroDevStudio.Dialogs
         // not a word boundary, continue searching
         if ( !isWholeWord )
         {
-          startPos = pos + 1;
-          if ( startPos >= SearchSource.Length )
+          if ( Upwards )
+          {
+            startPos = pos + SearchString.Length - 2;
+          }
+          else
+          {
+            startPos = pos + 1;
+          }
+          if ( ( startPos < 0 )
+          ||   ( startPos >= SearchSource.Length ) )
           {
             return new SearchLocation();
           }


### PR DESCRIPTION
The WholeWords discard branch updated startPos = pos + 1 and jumped back via goto find_next. For upwards search, String.LastIndexOf with that start index finds the same discarded match again for search strings of length <= 2, so pos and startPos stayed constant and the loop never terminated, freezing the UI thread.

Make the startPos update direction-dependent: for upwards search use startPos = pos + SearchString.Length - 2 (the largest index at which the discarded match would still be visible; any smaller value excludes it without losing pos - 1 as a possible match start), for downwards search keep pos + 1. Extend the abort condition to cover startPos < 0.