### PR TITLE
Fix out-of-bounds read in ParseTokenInfo for trailing single-char ope…

### DIFF
--- a/Common/Parser/Assembler/ASMFileParser.cs
+++ b/Common/Parser/Assembler/ASMFileParser.cs
@@ -12153,7 +12153,7 @@ namespace RetroDevStudio.Parser
                 }
               }
 
-              if ( ( charPos < Start + Length )
+              if ( ( charPos + 1 < Start + Length )
               &&   ( m_AssemblerSettings.AllowedTokenChars[Types.TokenInfo.TokenType.LABEL_GLOBAL].IndexOf( Source[tokenStartPos] ) != -1 )
               &&   ( m_AssemblerSettings.AllowedTokenChars[Types.TokenInfo.TokenType.LABEL_GLOBAL].IndexOf( Source[charPos + 1] ) != -1 ) )
               {


### PR DESCRIPTION
The UNKNOWN branch of ParseTokenInfo read Source[charPos + 1] guarded only by charPos < Start + Length, which is always true inside the loop. When the tokenized range ends at the string end and the last character is a single-character operator (e.g. a line like 'lda #3 *'), the read went past the end and threw IndexOutOfRangeException. Align the guard with the correct counterpart in the OPERATOR branch (charPos + 1 < Start + Length).