### PR TITLE
Fix InvalidOperationException when removing solution elements without…

### DIFF
--- a/C64Studio/Documents/SolutionExplorer.cs
+++ b/C64Studio/Documents/SolutionExplorer.cs
@@ -1207,7 +1207,10 @@ namespace RetroDevStudio.Documents
 
     void RemoveElement( ProjectElement Element )
     {
-      foreach ( var childNode in Element.Node.Nodes )
+      // iterate over a copy - the recursion removes nodes from this collection
+      var nodesToRemove = new List<DecentForms.TreeView.TreeNode>();
+      nodesToRemove.AddRange( Element.Node.Nodes );
+      foreach ( var childNode in nodesToRemove )
       {
         ProjectElement childElement = ElementFromNode( childNode );
         if ( childElement != null )


### PR DESCRIPTION
RemoveElement iterated the live child TreeNodeCollection while the recursion removed nodes from that same collection via Solution.RemoveElement -> Node.Remove(). The DecentForms enumerator is fail-fast, so removing the first child aborted the run with an InvalidOperationException, leaving the remaining children in the tree and the project inconsistent. Iterate over a snapshot copy of the children instead, mirroring the pattern already used by RemoveAndDeleteElement.