### PR TITLE
Add range guards to UpdateMemory to reject out-of-range offsets

### DIFF
--- a/C64Studio/Debugging.cs
+++ b/C64Studio/Debugging.cs
@@ -792,6 +792,14 @@ namespace RetroDevStudio
         memoryView = Core.Debugging.MemoryRAM;
       }
 
+      if ( ( Offset < 0 )
+      ||   ( Offset + (int)Data.Length > memoryView.Flags.Length ) )
+      {
+        // discard the whole update to keep Flags/RAM and the memory views consistent
+        Debug.Log( "UpdateMemory: discarding out of range update, offset " + Offset + ", length " + Data.Length + ", limit " + memoryView.Flags.Length );
+        return;
+      }
+
       for ( int i = 0; i < Data.Length; ++i )
       {
         byte    ramByte = Data.ByteAt( i );

--- a/C64Studio/Documents/DebugMemory.cs
+++ b/C64Studio/Documents/DebugMemory.cs
@@ -466,6 +466,14 @@ namespace RetroDevStudio.Documents
     {
       int Offset = Request.Parameter1;
 
+      if ( ( Offset < 0 )
+      ||   ( Offset + (int)Data.Length > hexView.ByteProvider.Length ) )
+      {
+        // discard the whole update, providers would throw on out of range indices
+        Debug.Log( "UpdateMemory: discarding out of range update, offset " + Offset + ", length " + Data.Length + ", limit " + hexView.ByteProvider.Length );
+        return;
+      }
+
       for ( int i = 0; i < Data.Length; ++i )
       {
         byte    ramByte = Data.ByteAt( i );


### PR DESCRIPTION
the wind of change