### PR TITLE
Fix swapped coordinates in FastImage.Box/BoxAlpha default fallback

### DIFF
--- a/Common/Common/FastImage.cs
+++ b/Common/Common/FastImage.cs
@@ -3009,7 +3009,7 @@ namespace GR.Image
           {
             for ( int j = 0; j < Width; ++j )
             {
-              SetPixelData( i, j, Value );
+              SetPixelData( X + j, Y + i, Value );
             }
           }
           break;
@@ -3146,7 +3146,7 @@ namespace GR.Image
           {
             for ( int j = 0; j < Width; ++j )
             {
-              SetPixelData( i, j, Value );
+              SetPixelData( X + j, Y + i, Value );
             }
           }
           break;


### PR DESCRIPTION
The default fallback paths for unsupported bit depths passed the raw loop indices to SetPixelData instead of the clipped rectangle offsets. This filled a transposed region anchored at the origin and left parts of the target rectangle untouched (e.g. stale pixels when re-loading a 1bpp/4bpp bitmap in the graphics import dialog). Pass X + j / Y + i to match the optimized code paths.