### PR TITLE
Fix data loss on partial VICE 2.4 response lines without newline

### DIFF
--- a/C64Studio/Debugger/VICERemoteDebugger.cs
+++ b/C64Studio/Debugger/VICERemoteDebugger.cs
@@ -273,9 +273,10 @@ namespace RetroDevStudio
             && ( m_ViceVersion >= WinViceVersion.V_2_4 ) )
             {
               // Vice 2.4 sometimes does NOT send an ending line break
+              // take the buffered data as a complete final line instead of dropping it
+              stringData = Encoding.ASCII.GetString( m_ReceivedDataBin.Data(), 0, (int)m_ReceivedDataBin.Length );
+              linePos = stringData.Length;
               m_ReceivedDataBin.Clear();
-              ProcessResponse();
-              break;
             }
             else
             {


### PR DESCRIPTION
In VICERemoteDebugger.OnDataReceived the VICE>=2.4 branch dropped a buffered 10-byte response without newline via Clear() before ProcessResponse() ran, losing the data entirely. TCP fragments of exactly 10 bytes and newline-less responses could therefore stall the debug step (open request, blocked queue).

Now the buffered content is taken over as a complete final line into stringData, the buffer is consumed afterwards and the existing stringData line processing (incl. the established Length==10 special case) handles it like any other final line.