### PR TITLE
Off-by-one-Fehler im Screen-Export behoben

### DIFF
--- a/C64Studio/Documents/CharsetScreenEditor.cs
+++ b/C64Studio/Documents/CharsetScreenEditor.cs
@@ -3706,9 +3706,9 @@ namespace RetroDevStudio.Documents
             for ( int i = 0; i < count; ++i )
             {
               if ( ( first + i >= 0 )
-              &&   ( first + i <= m_CharsetScreen.Screens.Count ) )
+              &&   ( first + i < m_CharsetScreen.Screens.Count ) )
               {
-                exportInfo.ScreensToExport.Add( i );
+                exportInfo.ScreensToExport.Add( first + i );
               }
             }
           }


### PR DESCRIPTION
Die if-Bedingung wurde angepasst, um einen Bereichsfehler zu vermeiden ((first + i < m_CharsetScreen.Screens.Count)). Zudem wird beim Hinzufügen zu exportInfo.ScreensToExport nun der korrekte Index (first + i) verwendet, sodass die richtigen Screens exportiert werden.